### PR TITLE
upgrade to 17.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,9 @@ ADD image/home $DOCKER_HOME/
 
 # Install system packages
 RUN add-apt-repository ppa:webupd8team/atom && \
-    add-apt-repository ppa:jonathonf/gcc-7.1 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
-        gcc-7 \
-        g++-7 \
         gfortran \
         cmake \
         bison \
@@ -37,6 +34,7 @@ RUN add-apt-repository ppa:webupd8team/atom && \
         ccache \
         \
         liblapack-dev \
+        liblapacke-dev \
         libmpich-dev \
         libopenblas-dev \
         mpich \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Builds a Docker image with Ubuntu 16.04, g++-5.4, g++-7.1, clang, Atom, LAPACK, ddd,
+# Builds a Docker image with Ubuntu 17.10, g++-7.2, clang, Atom, LAPACK, ddd,
 # valgrind, and mpich for "AMS 562: Introduction to Scientific Programming in C++"
 # at Stony Brook University
 #

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Docker Image for AMS 562
-This Docker image provides the Ubuntu 16.04 environment with X Windows for the class "AMS 562: Introduction to Scientific Programming in C++" at Stony Brook University. The image runs the lightweight LXDE Windows Manager, and has `g++-5.4`, `g++-7.1`, `Atom`, `LAPACK`, `valgrind`, and `ddd` preinstalled. The X Windows will display in your web browser in full-screen mode.
+This Docker image provides the Ubuntu 17.10 environment with X Windows for the class "AMS 562: Introduction to Scientific Programming in C++" at Stony Brook University. The image runs the lightweight LXDE Windows Manager, and has `g++-7.2`, `Atom`, `LAPACK`, `valgrind`, and `ddd` preinstalled. The X Windows will display in your web browser in full-screen mode.
 You can use this Docker image on 64-bit Linux, Mac or Windows. It allows you to use the same programming environment regardless which OS you are running on your laptop or desktop.
 
 ![screenshot](https://raw.github.com/compdatasci/ams562-desktop/master/screenshots/screenshot.png)


### PR DESCRIPTION
Students require LAPACKE for their final project. I have tested the build on docker hub. I think it's also sweet to upgrade the based image to 17.10 so that we can remove the ppa gcc.